### PR TITLE
Update example to throw an unauthorized exception on invalid credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ $credentialsProvider = function ($id) {
             '12345'      // identifier, default: null
         );
     }
+
+    throw new UnauthorizedException("Unknown credentials");
 };
 
 // A complete example


### PR DESCRIPTION
Server expects that credentials provider will always gives an
Cretaintails object. Therefore throw unauthorized exception if no
matching credeaintils were found.

Update readme so that it will notice to the user.
